### PR TITLE
Fix for Silverstripe 3.5.4+ cached image issues and weird warning mes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ which also uses injector for Image)
 Injector:
   Image:
     class: SVGImage
+  Image_Cached:
+    class: SVGImage_Cached
 ```
 
 ## Allowing SVG in scaffolded UploadFields

--- a/code/SVGImage.php
+++ b/code/SVGImage.php
@@ -90,20 +90,134 @@ class SVGImage extends \Image
         if($this->getExtension()=='svg') return $this;
 
         // else just forward to regular Image class
-        //return call_user_func_array('parent::getFormattedImage',func_get_args());
+        return call_user_func_array('parent::getFormattedImage',func_get_args());
+    }
 
-        $args = func_get_args();
 
-        if($this->exists()) {
-            $cacheFile = call_user_func_array(array($this, "cacheFilename"), $args);
-
-            if(!file_exists(Director::baseFolder()."/".$cacheFile) || self::$flush) {
-                call_user_func_array(array($this, "generateFormattedImage"), $args);
-            }
-
-            $cached = new Image_Cached($cacheFile, false, $this);
-            return $cached;
+    //
+    // SVGTemplate integration
+    //
+    public function IsSVG(){
+        if($this->getExtension()=='svg') {
+//            var_dump('svg');
+            return true;
         }
+        return false;
+    }
+
+    public function SVG($id = null){
+        if( ! $this->IsSVG() || ! class_exists('SVGImage_Template')) return false;
+        $fileparts = explode(DIRECTORY_SEPARATOR, $this->Filename);
+        $svg = new SVGImage_Template(array_pop($fileparts), $id);
+        $svg->customBasePath(implode(DIRECTORY_SEPARATOR, $fileparts));
+        return $svg;
+    }
+
+    public function SVG_RAW_Inline(){
+        $filePath = BASE_PATH . DIRECTORY_SEPARATOR . $this->Filename;
+        if (file_exists($filePath)) {
+            return file_get_contents($filePath);
+        }
+    }
+
+}
+
+/**
+ * Class SVGImage_Cached
+ *
+ * This is required to ensure manipulated images get their methods overidden too
+ */
+class SVGImage_Cached extends Image_Cached
+{
+
+    private static $flush = false;
+
+    public function getFileType(){
+        if($this->getExtension()=='svg') return "SVG image - good for line drawings";
+
+        return parent::getFileType();
+    }
+
+    public function getDimensions($dim = "string") {
+        if($this->getExtension()!='svg' || !$this->exists()) return parent::getDimensions($dim);
+
+        if($this->getField('Filename')) {
+            $filePath = $this->getFullPath();
+
+            // parse SVG
+            $out = new DOMDocument();
+            $out->load($filePath);
+            if (!is_object($out) || !is_object($out->documentElement)) {
+                return false;
+            }
+            // get dimensions from viewbox or else from width/height on root svg element
+            $root = $out->documentElement;
+            if($root->hasAttribute('viewBox')){
+                $vbox = explode(' ',$root->getAttribute('viewBox'));
+                $size[0] = $vbox[2] - $vbox[0];
+                $size[1] = $vbox[3] - $vbox[1];
+            } else if($root->hasAttribute('width')) {
+                $size[0] = $root->getAttribute('width');
+                $size[1] = $root->getAttribute('height');
+            } else {
+                return ($dim === "string") ? "No size set (scalable)" : 0;
+            }
+            // (regular logic/from Image class)
+            return ($dim === "string") ? "$size[0]x$size[1]" : $size[$dim];
+
+        }
+    }
+
+    /**
+     * Return an XHTML img tag for this Image,
+     * or NULL if the image file doesn't exist on the filesystem.
+     *
+     * @return string
+     */
+//    public function getTag() {
+//        if($this->exists()) {
+//            $url = $this->getURL();
+//            $title = ($this->Title) ? $this->Title : $this->Filename;
+//            if($this->Title) {
+//                $title = Convert::raw2att($this->Title);
+//            } else {
+//                if(preg_match("/([^\/]*)\.[a-zA-Z0-9]{1,6}$/", $title, $matches)) {
+//                    $title = Convert::raw2att($matches[1]);
+//                }
+//            }
+//            return "<img src=\"$url\" alt=\"$title\" test />";
+//        }
+//    }
+
+    /**
+     * Scale image proportionally to fit within the specified bounds
+     *
+     * @param integer $width The width to size within
+     * @param integer $height The height to size within
+     * @return Image|null
+     */
+    public function Fit($width, $height) {
+        if($this->getExtension()=='svg') return $this;
+
+        // else just forward to regular Image class
+        return parent::Fit($width, $height);
+    }
+
+    /**
+     * Return an image object representing the image in the given format.
+     * This image will be generated using generateFormattedImage().
+     * The generated image is cached, to flush the cache append ?flush=1 to your URL.
+     *
+     * Just pass the correct number of parameters expected by the working function
+     *
+     * @param string $format The name of the format.
+     * @return Image_Cached|null
+     */
+    public function getFormattedImage($format) {
+        if($this->getExtension()=='svg') return $this;
+
+        // else just forward to regular Image class
+        return call_user_func_array('parent::getFormattedImage',func_get_args());
     }
 
 


### PR DESCRIPTION
This is my fix for those weird issues regarding cached images in Silverstripe versions starting with 3.5.4 and above.

Figured this out based on the same issues and comments / code changes from the jonom silverstripe-focuspoint module.

In big lines this is what I did:

1. created an SVGImage_Cached class which extends the Image_Cached class
2. changed the getFormattedImage() method in the SVGImage class (to a previous version)
3. added all the methods from SVGImage class to the SVGImage_Cached class as well
4. updated README.md to make sure that the following config is used in the YAML configuration file (notice that SVGImage_Cached too it's added to the Injector thing)

Here are some links I used to make all these changes:

https://github.com/jonom/silverstripe-focuspoint/blob/fix-image-load/code/FPImage.php - notice the FPImage_Cached class there

https://github.com/jonom/silverstripe-focuspoint/issues/44 - see jonom's comment from 26 Jul 2017 - regarding the YAML configuration changes he made in his module